### PR TITLE
Force-move the v3 tag on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,17 @@ jobs:
         body_path: ".changes/${{ steps.latest.outputs.output }}.md"
         tag_name: "${{ steps.latest.outputs.output }}"
 
+    # softprops/action-gh-release's tag_name only picks where to create a tag
+    # the first time it exists. On every release after the first, v3 already
+    # exists, so it just updates that release's body/notes and leaves the
+    # underlying git tag pointing at whatever commit it was last on. Move it
+    # ourselves so `uses: miniscruff/changie-action@v3` actually tracks the
+    # latest v3.x.y release.
+    - name: Move major version tag
+      run: |
+        git tag -f v3
+        git push origin v3 --force
+
     - name: Release
       uses: softprops/action-gh-release@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,7 @@ jobs:
         body_path: ".changes/${{ steps.latest.outputs.output }}.md"
         tag_name: "${{ steps.latest.outputs.output }}"
 
-    # softprops/action-gh-release's tag_name only picks where to create a tag
-    # the first time it exists. On every release after the first, v3 already
-    # exists, so it just updates that release's body/notes and leaves the
-    # underlying git tag pointing at whatever commit it was last on. Move it
-    # ourselves so `uses: miniscruff/changie-action@v3` actually tracks the
-    # latest v3.x.y release.
+    # softprops/action-gh-release only places a tag on creation, so it won't move v3 on its own
     - name: Move major version tag
       run: |
         git tag -f v3


### PR DESCRIPTION
## Summary
- After the v3.0.1 release, `v3` was still pointing at the v3.0.0 commit (`git ls-remote --tags` confirmed it), even though the release workflow's second `softprops/action-gh-release` step reported success. Anyone pinning `uses: miniscruff/changie-action@v3` was stuck on the old build — notably, the pre-ESM-fix `dist/index.js` from before #348/#349.
- Root cause: `softprops/action-gh-release`'s `target_commitish` only decides where to place a tag the first time it's created. Since `v3` already existed from the v3.0.0 release, this run's log showed `Found release v3 (with id=...)` — it just updated the release notes and left the underlying git tag ref untouched.
- I manually force-moved `v3` -> the v3.0.1 commit to fix the immediate issue. This PR makes it automatic going forward.

## Change
Add a step between the two release steps that does the actual `git tag -f v3 && git push origin v3 --force`, so the tag itself always tracks the latest v3.x.y commit regardless of whether the GitHub release for `v3` already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)